### PR TITLE
Set max token length to 32 (the db limit)

### DIFF
--- a/lib/AppInfo/AppConstants.php
+++ b/lib/AppInfo/AppConstants.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OCA\CfgShareLinks\AppInfo;
+
+class AppConstants {
+	public const DEFAULT_VALID_TOKEN_REGEX = "/^[a-zA-Z0-9_\-+]+$/";
+	public const DEFAULT_MIN_TOKEN_LENGTH = 3;
+	public const MAX_TOKEN_LENGTH = 32; // Nextcloud saves the token in VARCHAR(32)
+
+	public const DEFAULT_LABEL_MODE = 0;
+	public const DEFAULT_CUSTOM_LABEL = 'Custom link';
+
+	public const DEFAULT_DELETE_REMOVED_SHARE_CONFLICTS = false;
+}

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -26,7 +26,9 @@
 
 namespace OCA\CfgShareLinks\Controller;
 
+use OCA\CfgShareLinks\AppInfo\AppConstants;
 use OCA\CfgShareLinks\AppInfo\Application;
+use OCA\CfgShareLinks\Enums\SettingsKey;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
@@ -36,6 +38,8 @@ use OCP\IRequest;
 class SettingsController extends Controller {
 	public function __construct(
 		private IAppConfig $appConfig,
+		private AppConstants $appConstants,
+		private SettingsKey $settingsKey,
 		IRequest           $request
 	) {
 		parent::__construct(Application::APP_ID, $request);
@@ -45,25 +49,25 @@ class SettingsController extends Controller {
 		switch ($key) {
 			case 'default_label_mode':
 				if (is_numeric($value) && (int)$value >= 0 && (int)$value <= 2) {
-					$this->appConfig->setAppValue('default_label_mode', (int)$value);
+					$this->appConfig->setAppValue($this->settingsKey::DefaultLabelMode, (int)$value);
 					return new DataResponse(['message' => 'Saved'], Http::STATUS_OK);
 				}
 				break;
 			case 'default_label':
 				if (strlen($value) >= 1) {
-					$this->appConfig->setAppValue('default_label', $value);
+					$this->appConfig->setAppValue($this->settingsKey::DefaultCustomLabel, $value);
 					return new DataResponse(['message' => 'Saved'], Http::STATUS_OK);
 				}
 				break;
 			case 'min_token_length':
 				if (is_numeric($value) && (int)$value >= 1) {
-					$this->appConfig->setAppValue('min_token_length', (int)$value);
+					$this->appConfig->setAppValue($this->settingsKey::MinTokenLength, (int)$value);
 					return new DataResponse(['message' => 'Saved'], Http::STATUS_OK);
 				}
 				break;
 			case 'deleteRemovedShareConflicts':
 				if (is_numeric($value) && (int)$value >= 0) {
-					$this->appConfig->setAppValue('deleteRemovedShareConflicts', (int)$value > 0);
+					$this->appConfig->setAppValue($this->settingsKey::DeleteRemovedShareConflicts, (int)$value > 0);
 					return new DataResponse(['message' => 'Saved'], Http::STATUS_OK);
 				}
 				break;
@@ -74,10 +78,10 @@ class SettingsController extends Controller {
 
 	public function fetch(): DataResponse {
 		$settings = [
-			'defaultLabelMode' => $this->appConfig->getAppValue('default_label_mode', 0),
-			'defaultLabel' => $this->appConfig->getAppValue('default_label', 'Custom link'),
-			'minTokenLength' => $this->appConfig->getAppValue('min_token_length', 3),
-			'deleteRemovedShareConflicts' => $this->appConfig->getAppValue('deleteRemovedShareConflicts', false)
+			'defaultLabelMode' => $this->appConfig->getAppValue($this->settingsKey::DefaultLabelMode, $this->appConstants::DEFAULT_LABEL_MODE),
+			'defaultLabel' => $this->appConfig->getAppValue($this->settingsKey::DefaultCustomLabel, $this->appConstants::DEFAULT_CUSTOM_LABEL),
+			'minTokenLength' => $this->appConfig->getAppValue($this->settingsKey::MinTokenLength, $this->appConstants::DEFAULT_MIN_TOKEN_LENGTH),
+			'deleteRemovedShareConflicts' => $this->appConfig->getAppValue($this->settingsKey::DeleteRemovedShareConflicts, $this->appConstants::DEFAULT_DELETE_REMOVED_SHARE_CONFLICTS)
 		];
 
 		return new DataResponse($settings, Http::STATUS_OK);

--- a/lib/Enums/LinkLabelMode.php
+++ b/lib/Enums/LinkLabelMode.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace OCA\CfgShareLinks\Enums;
+
+// TODO: replace with enum after setting min PHP version to 8.1
+class LinkLabelMode {
+	public const NoLabel = 0;
+	public const SameAsToken = 1;
+	public const UserSpecified = 2;
+}

--- a/lib/Enums/SettingsKey.php
+++ b/lib/Enums/SettingsKey.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace OCA\CfgShareLinks\Enums;
+
+// TODO: replace with enum after setting min PHP version to 8.1
+class SettingsKey {
+	public const DefaultLabelMode = 'default_label_mode';
+	public const DefaultCustomLabel = 'default_label';
+	public const MinTokenLength = 'min_token_length';
+	public const DeleteRemovedShareConflicts = 'deleteRemovedShareConflicts';
+}

--- a/lib/Settings/LinksAdmin.php
+++ b/lib/Settings/LinksAdmin.php
@@ -26,7 +26,9 @@
 
 namespace OCA\CfgShareLinks\Settings;
 
+use OCA\CfgShareLinks\AppInfo\AppConstants;
 use OCA\CfgShareLinks\AppInfo\Application;
+use OCA\CfgShareLinks\Enums\SettingsKey;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\Settings\ISettings;
@@ -34,16 +36,18 @@ use OCP\Util;
 
 class LinksAdmin implements ISettings {
 	public function __construct(
-		private IAppConfig $appConfig
+		private IAppConfig $appConfig,
+		private AppConstants $appConstants,
+		private SettingsKey $settingsKey,
 	) {
 	}
 
 	public function getForm(): TemplateResponse {
 		$parameters = [
-			'defaultLabelMode' => $this->appConfig->getAppValue('default_label_mode', 0),
-			'defaultLabel' => $this->appConfig->getAppValue('default_label', 'Custom link'),
-			'minTokenLength' => $this->appConfig->getAppValue('min_token_length', 3),
-			'deleteRemovedShareConflicts' => $this->appConfig->getAppValue('deleteRemovedShareConflicts', false)
+			'defaultLabelMode' => $this->appConfig->getAppValue($this->settingsKey::DefaultLabelMode, $this->appConstants::DEFAULT_LABEL_MODE),
+			'defaultLabel' => $this->appConfig->getAppValue($this->settingsKey::DefaultCustomLabel, $this->appConstants::DEFAULT_CUSTOM_LABEL),
+			'minTokenLength' => $this->appConfig->getAppValue($this->settingsKey::MinTokenLength, $this->appConstants::DEFAULT_MIN_TOKEN_LENGTH),
+			'deleteRemovedShareConflicts' => $this->appConfig->getAppValue($this->settingsKey::DeleteRemovedShareConflicts, $this->appConstants::DEFAULT_DELETE_REMOVED_SHARE_CONFLICTS)
 		];
 
 		Util::addScript(Application::APP_ID, 'cfg_share_links-settings-admin');

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -2,7 +2,9 @@
 
 namespace OCA\CfgShareLinks\Tests\Unit\Controller;
 
+use OCA\CfgShareLinks\AppInfo\AppConstants;
 use OCA\CfgShareLinks\Controller\SettingsController;
+use OCA\CfgShareLinks\Enums\SettingsKey;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\IRequest;
@@ -16,7 +18,12 @@ class SettingsControllerTest extends TestCase {
 	protected function setUp(): void {
 		$this->appConfig = $this->getMockBuilder(IAppConfig::class)->getMock();
 		$this->request = $this->getMockBuilder(IRequest::class)->getMock();
-		$this->controller = new SettingsController($this->appConfig, $this->request);
+		$this->controller = new SettingsController(
+			$this->appConfig,
+			new AppConstants(),
+			new SettingsKey(),
+			$this->request,
+		);
 	}
 
 	public function testFetch() {

--- a/tests/Unit/Service/ShareServiceTest.php
+++ b/tests/Unit/Service/ShareServiceTest.php
@@ -50,7 +50,7 @@ class ShareServiceTest extends TestCase {
 			$this->mapper,
 			new AppConstants(),
 			new SettingsKey(),
-            new LinkLabelMode(),
+			new LinkLabelMode(),
 			$this->userId,
 		);
 	}

--- a/tests/Unit/Service/ShareServiceTest.php
+++ b/tests/Unit/Service/ShareServiceTest.php
@@ -2,7 +2,9 @@
 
 namespace OCA\CfgShareLinks\Tests\Unit\Service;
 
+use OCA\CfgShareLinks\AppInfo\AppConstants;
 use OCA\CfgShareLinks\Db\CfgShareMapper;
+use OCA\CfgShareLinks\Enums\SettingsKey;
 use OCA\CfgShareLinks\Service\InvalidTokenException;
 use OCA\CfgShareLinks\Service\ShareService;
 use OCP\AppFramework\Services\IAppConfig;
@@ -45,6 +47,8 @@ class ShareServiceTest extends TestCase {
 			$this->l10n,
 			$this->appConfig,
 			$this->mapper,
+			new AppConstants(),
+			new SettingsKey(),
 			$this->userId,
 		);
 	}

--- a/tests/Unit/Service/ShareServiceTest.php
+++ b/tests/Unit/Service/ShareServiceTest.php
@@ -4,6 +4,7 @@ namespace OCA\CfgShareLinks\Tests\Unit\Service;
 
 use OCA\CfgShareLinks\AppInfo\AppConstants;
 use OCA\CfgShareLinks\Db\CfgShareMapper;
+use OCA\CfgShareLinks\Enums\LinkLabelMode;
 use OCA\CfgShareLinks\Enums\SettingsKey;
 use OCA\CfgShareLinks\Service\InvalidTokenException;
 use OCA\CfgShareLinks\Service\ShareService;
@@ -49,6 +50,7 @@ class ShareServiceTest extends TestCase {
 			$this->mapper,
 			new AppConstants(),
 			new SettingsKey(),
+            new LinkLabelMode(),
 			$this->userId,
 		);
 	}


### PR DESCRIPTION
Nextcloud saves the share token in `varchar(32)`, limit the custom token to 32 characters.